### PR TITLE
fix languages attribute in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Check this [stackblitz](https://stackblitz.com/edit/ngx-highlightjs)
 
 - **[highlight]**: (string), Accept code string to highlight, default `null`
 
-- **[language]**: (string[]), an array of language names and aliases restricting auto detection to only these languages, default: `null`
+- **[languages]**: (string[]), an array of language names and aliases restricting auto detection to only these languages, default: `null`
 
 - **(highlighted)**: Stream that emits `HighlightResult` object when element is highlighted.
 


### PR DESCRIPTION
The documentation incorrectly states to use the `[language]` directive. But it's the plural version `[languages]` that must be used.