### PR TITLE
Expose hlsj for external libraries to use

### DIFF
--- a/projects/ngx-highlightjs/src/lib/highlight.service.ts
+++ b/projects/ngx-highlightjs/src/lib/highlight.service.ts
@@ -2,8 +2,15 @@ import { Injectable, Inject, Optional } from '@angular/core';
 import { HighlightConfig, HighlightResult, HighlightLanguage, HighlightOptions, HIGHLIGHT_OPTIONS } from './highlight.model';
 import hljs from 'highlight.js/lib/highlight.js';
 
-(document as any).hljs = hljs;
-(window as any).eval('var hljs = document.hljs');
+function exposeHlJsGlobally() {
+  if(!window || !window.eval || !document) {
+    return false;
+  }
+  (document as any).hljs = hljs;
+  (window as any).eval('var hljs = document.hljs');
+  return true;
+}
+exposeHlJsGlobally()
 
 @Injectable({
   providedIn: 'root'
@@ -110,3 +117,5 @@ export class HighlightJS {
     return hljs.getLanguage(name);
   }
 }
+
+

--- a/projects/ngx-highlightjs/src/lib/highlight.service.ts
+++ b/projects/ngx-highlightjs/src/lib/highlight.service.ts
@@ -2,15 +2,15 @@ import { Injectable, Inject, Optional } from '@angular/core';
 import { HighlightConfig, HighlightResult, HighlightLanguage, HighlightOptions, HIGHLIGHT_OPTIONS } from './highlight.model';
 import hljs from 'highlight.js/lib/highlight.js';
 
-function exposeHlJsGlobally() {
-  if(!window || !window.eval || !document) {
+function exposeHljsGlobally() {
+  if(!(window as any).eval || !window.document) {
     return false;
   }
-  (document as any).hljs = hljs;
+  (window.document as any).hljs = hljs;
   (window as any).eval('var hljs = document.hljs');
   return true;
 }
-exposeHlJsGlobally()
+exposeHljsGlobally()
 
 @Injectable({
   providedIn: 'root'

--- a/projects/ngx-highlightjs/src/lib/highlight.service.ts
+++ b/projects/ngx-highlightjs/src/lib/highlight.service.ts
@@ -2,6 +2,9 @@ import { Injectable, Inject, Optional } from '@angular/core';
 import { HighlightConfig, HighlightResult, HighlightLanguage, HighlightOptions, HIGHLIGHT_OPTIONS } from './highlight.model';
 import hljs from 'highlight.js/lib/highlight.js';
 
+(document as any).hljs = hljs;
+(window as any).eval('var hljs = document.hljs');
+
 @Injectable({
   providedIn: 'root'
 })

--- a/projects/ngx-highlightjs/src/lib/highlight.service.ts
+++ b/projects/ngx-highlightjs/src/lib/highlight.service.ts
@@ -3,11 +3,10 @@ import { HighlightConfig, HighlightResult, HighlightLanguage, HighlightOptions, 
 import hljs from 'highlight.js/lib/highlight.js';
 
 function exposeHljsGlobally() {
-  if(!(window as any).eval || !window.document) {
+  if(typeof window === 'undefined') {
     return false;
   }
-  (window.document as any).hljs = hljs;
-  (window as any).eval('var hljs = document.hljs');
+  (window as any).hljs = hljs;
   return true;
 }
 exposeHljsGlobally()


### PR DESCRIPTION
I have exposed the hlsj library globally, so other third party libraries are able to communicate with it. 