### PR TITLE
docs: update Angular 10 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,15 +150,18 @@ To avoid this warning, add the following in your `angular.json`
     "project-name": {
       "architect": {
         "build": {
-          "allowedCommonJsDependencies": [
-            "highlight.js"
-          ]
+          "options": {
+            "allowedCommonJsDependencies": [
+              "highlight.js"
+            ]
+          }
         }
       }
     }
   }
 }
 ```
+Read more about [CommonJS dependencies configuration](https://angular.io/guide/build#configuring-commonjs-dependencies)
 
 ## Plus package
 


### PR DESCRIPTION
"allowedCommonJsDependencies" has been moved under "architect.build.options.allowedCommonJsDependencies".