### PR TITLE
Add support for trusted types (CSP)

### DIFF
--- a/projects/ngx-highlightjs/src/lib/highlight.ts
+++ b/projects/ngx-highlightjs/src/lib/highlight.ts
@@ -14,6 +14,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { animationFrameScheduler } from 'rxjs';
 import { HighlightJS } from './highlight.service';
 import { HIGHLIGHT_OPTIONS, HighlightOptions, HighlightAutoResult } from './highlight.model';
+import { trustedHTMLFromStringBypass } from './trusted-types';
 
 @Directive({
   host: {
@@ -41,6 +42,7 @@ export class Highlight implements OnChanges {
 
   // Stream that emits when code string is highlighted
   @Output() highlighted = new EventEmitter<HighlightAutoResult>();
+
 
   constructor(el: ElementRef,
               private _hljs: HighlightJS,
@@ -117,7 +119,9 @@ export class Highlight implements OnChanges {
 
   private setInnerHTML(content: string | null) {
     animationFrameScheduler.schedule(() =>
-      this._nativeElement.innerHTML = this._sanitizer.sanitize(SecurityContext.HTML, content) || ''
+      this._nativeElement.innerHTML = trustedHTMLFromStringBypass(
+        this._sanitizer.sanitize(SecurityContext.HTML, content) || ''
+      )
     );
   }
 }

--- a/projects/ngx-highlightjs/src/lib/trusted-types.ts
+++ b/projects/ngx-highlightjs/src/lib/trusted-types.ts
@@ -1,0 +1,31 @@
+/**
+ * Enable usage of the library together with "trusted-types" HTTP Content-Security-Policy (CSP)
+ *
+ * Can be added to angular.json -> serve -> options -> headers to try it out in DEV mode
+ * "Content-Security-Policy": "trusted-types ngx-highlightjs; require-trusted-types-for 'script'"
+ *
+ * Read more...
+ * Angular Security: https://angular.io/guide/security#enforcing-trusted-types
+ * Trusted Types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types
+ */
+let policy;
+
+function getPolicy() {
+  if (!policy) {
+    try {
+      policy = (window as any)?.trustedTypes?.createPolicy('ngx-highlightjs', {
+        createHTML: (s: string) => s,
+      });
+    } catch {
+      // trustedTypes.createPolicy throws if called with a name that is
+      // already registered, even in report-only mode. Until the API changes,
+      // catch the error not to break the applications functionally. In such
+      // cases, the code will fall back to using strings.
+    }
+  }
+  return policy;
+}
+
+export function trustedHTMLFromStringBypass(html: string): string {
+  return getPolicy()?.createHTML(html) || html;
+}


### PR DESCRIPTION
Hey there!

TLDR; This PR enables apps served with `require-trusted-types-for 'script'` CSP header to work with ngx-highlightjs.

We (and probably other folks out there) need to be able to use the **HTTP Content-Security-Policy (CSP) [trusted-types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types)**

The gist of it is that the ngx-highlightjs uses `innerHTML` assignment (with Angular sanitizer which is correct) but still evaluated as a security risk by the CSP. Therefore we have to create a policy to allow consumers to **trust** the library.

In consumer application then CSP can be enabled for local development and testing using

```
       "serve": {
          "builder": "@angular-devkit/build-angular:dev-server",
          "options": {
            "browserTarget": "rwc-b2c-components-showcase-rwc:build",
            "headers": {
              "Content-Security-Policy": "trusted-types ngx-highlightjs angular angular#unsafe-bypass angular#bundler; require-trusted-types-for 'script'"
            }
          }
        },
```

Keep in mind that in the end it is the responsibility of server to set correct CSP headers when serving the application (not responsibility of this lib).

This solution is heavily inspired by [Angular own solution](https://github.com/angular/angular/blob/3a60063a54d850c50ce962a8a39ce01cfee71398/packages/core/src/util/security/trusted_types_bypass.ts)
Read more about trusted types and their [support in Angular](https://angular.io/guide/security#enforcing-trusted-types)
