### PR TITLE
Add install by pnpm instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Install with **NPM**
 npm i ngx-highlightjs
 ```
 
+Install with **PNPM**
+```bash
+pnpm add ngx-highlightjs highlight.js
+```
+
 <a name="usage"/>
 
 ## Usage


### PR DESCRIPTION
Add install by pnpm instruction

> pnpm uses symlinks to add only the direct dependencies of the project into the root of the modules directory.

So if the package manager is pnpm, you should add the highlight.js package explicitly.